### PR TITLE
Loop through all request headers to find 'Transfer-Encoding' header.

### DIFF
--- a/src/ngx_http_chunkin_util.c
+++ b/src/ngx_http_chunkin_util.c
@@ -443,7 +443,7 @@ ngx_http_chunkin_rm_header(ngx_list_t *l, ngx_table_elt_t *h)
             }
 
             part = part->next;
-            h = part->elts;
+            data = part->elts;
             i = 0;
         }
 


### PR DESCRIPTION
Agentzh,

I had an unusual use-case where chunk encoded requests were coming in with greater than 20 HTTP headers and the 'Transfer-Encoding' header was after the 20th header. The code that looks for the 'Transfer-Encoding' header was not looping through all HTTP headers because it was not moving on to the next data pointer correctly causing the 'Transfer-Encoding' header to not be found. This patch addresses that issue.

Thanks,
Steve
