### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -444,7 +444,7 @@ v0.19
 v0.18
 -----
 * added support for `chunk-extension` to the chunked parser as per [RFC 2616](http://tools.ietf.org/html/rfc2616#section-3.6.1), but we just ignore them (if any) because we don't understand them.
-* added more diagnostic information for certian error messages.
+* added more diagnostic information for certain error messages.
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
@agentzh, I've corrected a typographical error in the documentation of the [chunkin-nginx-module](https://github.com/agentzh/chunkin-nginx-module) project. Specifically, I've changed certian to certain. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
